### PR TITLE
made it past the build-and-package action, got stuck on deploy-to-aws…

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -137,7 +137,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: static-build
-          path: web/build
+          path: web/dist
 
   deploy-to-aws:
     if: github.ref == 'refs/heads/main'
@@ -178,12 +178,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: static-build
-          path: build/static
+          path: dist/static
 
       - name: Deploy NPM static resources
         run: |
           aws s3 cp \
-            build/static \
+            dist/static \
             s3://${ARTIFACTS_BUCKET}/static/ \
             --recursive
 


### PR DESCRIPTION
…. Since I switch to vite, I need to point to dist instead of build for npm resources