### PR TITLE
found the real issue (hopefully), the cognito domain was being malfor…

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -168,14 +168,17 @@ jobs:
           role-skip-session-tagging: true
 
       - name: Deploy to testing account
+        # Added COGNITO_DOMAIN_PREFIX so that I can copy+paste the full cognito domain address into secrets like the others
+        # Referenced in --parameter-overrides 
         run: |
+          COGNITO_DOMAIN_PREFIX=$(echo ${COGNITO_DOMAIN} | cut -d'.' -f1)
           sam deploy --stack-name ${STACK_NAME} \
             --template packaged-prod.yaml \
             --capabilities CAPABILITY_IAM \
             --region ${REGION} \
             --s3-bucket ${ARTIFACTS_BUCKET} \
             --no-fail-on-empty-changeset \
-            --parameter-overrides "S3Bucket=${ARTIFACTS_BUCKET} CognitoDomain=${COGNITO_DOMAIN} FrontendDeployment=remote" \
+            --parameter-overrides "S3Bucket=${ARTIFACTS_BUCKET} CognitoDomain=${COGNITO_DOMAIN_PREFIX} FrontendDeployment=remote" \
             --role-arn ${CLOUDFORMATION_EXECUTION_ROLE}
 
       - name: Download NPM static resources


### PR DESCRIPTION
…med with how I entered inputs into secrets from local deployment. Didnt need the full address, only the id. added protection against this so I can copy + paste the full string along with the other inputs